### PR TITLE
fix AuthorizationPolicyBuilder required param

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Step 2: Authorize all the things
 ```c#
 services.AddMvc(config =>
 {
-    var policy = new AuthorizationPolicyBuilder()
+    var policy = new AuthorizationPolicyBuilder("Cookie")
                      .RequireAuthenticatedUser()
                      .Build();
     config.Filters.Add(new AuthorizeFilter(policy));


### PR DESCRIPTION
At the time this workshop was created maybe the `AuthorizationPolicyBuilder` constructor didn't require params but it appears that it does now. I've updated the call in the README to match what the API seems to want.